### PR TITLE
更新一部分前端界面修改-软件测试3组

### DIFF
--- a/src/views/ssbc/invokeSmartContract/index.vue
+++ b/src/views/ssbc/invokeSmartContract/index.vue
@@ -5,7 +5,7 @@
       <el-col :span="22" :offset="1" :xs="24">
         <el-form label-width="80px">
           <el-form-item label="发起地址">
-            <el-select v-model="form.from" style="width: 100%" class="filter-item">
+            <el-select v-model="form.from" style="width: 100%" class="filter-item" filterable>
               <el-option v-for="user in userList" :key="user.address" :label="user.address" :value="user.address" @click.native="chooseSender(user)" />
             </el-select>
           </el-form-item>
@@ -20,14 +20,14 @@
             <el-input v-model.number="form.value" maxlength="10"/>
           </el-form-item>
           <el-form-item label="合约名称">
-            <el-select v-model="form.contract" style="width: 100%">
+            <el-select v-model="form.contract" style="width: 100%" filterable>
               <el-option v-for="contract in contractList" :key="contract.data.contractname" :label="contract.data.contractname + ' ( ' + contract.address + ' )'" :value="contract.data.contractname" @click.native="chooseContract(contract)" />
             </el-select>
           </el-form-item>
           <codemirror v-if="codeVisible" v-model="code" :options="cmOption" />
           <el-form-item v-if="codeVisible"/>
           <el-form-item label="方法">
-            <el-select v-model="form.method" style="width: 100%">
+            <el-select v-model="form.method" style="width: 100%" filterable>
               <el-option v-for="method in methodList" :key="method" :label="method" :value="method" @click.native="chooseMethod(method)" />
             </el-select>
           </el-form-item>

--- a/src/views/ssbc/postContract/index.vue
+++ b/src/views/ssbc/postContract/index.vue
@@ -33,7 +33,8 @@
             <el-input v-model="form.public_key" :disabled="true" />
           </el-form-item>
           <el-form-item label="合约名称">
-            <el-input v-model="form.name" oninput="this.value=this.value.replace(/[^[a-z0-9A-Z]/g,'')" @input="lengthRestriction" />
+            <el-input v-model="form.name" maxlength="200" show-word-limit placeholder="请输入长度不超过200位的合约名称，仅限大小写字母和数字"  oninput="this.value=this.value.replace(/[^[a-z0-9A-Z]/g,'')" @input="lengthRestriction" />
+
           </el-form-item>
           <el-form-item label="合约生成">
             <el-collapse accordion>

--- a/src/views/ssbc/postContract/index.vue
+++ b/src/views/ssbc/postContract/index.vue
@@ -5,7 +5,7 @@
         <el-alert
           title="智能合约编辑与上传"
           type="info"
-          description="请使用Go语言编写"
+          description="请使用Go语言编写（推荐使用Go语言1.16.3以下版本编写）"
           show-icon
         />
       </el-col>

--- a/src/views/ssbc/postContract/index.vue
+++ b/src/views/ssbc/postContract/index.vue
@@ -16,7 +16,7 @@
         <el-form label-width="80px">
 
           <el-form-item label="发起地址">
-            <el-select v-model="form.account" style="width: 100%" class="filter-item">
+            <el-select v-model="form.account" style="width: 100%" class="filter-item" filterable>
               <el-option
                 v-for="user in userList"
                 :key="user.address"

--- a/src/views/ssbc/postContract/index.vue
+++ b/src/views/ssbc/postContract/index.vue
@@ -74,7 +74,7 @@
           </el-form-item>
           <codemirror v-model="form.code" :options="cmOption" />
           <el-form-item />
-          <el-button type="primary" :disabled="disable" @click="postContract">创建合约</el-button>
+          <el-button type="primary" :disabled="disable" @click="postContract">发布合约</el-button>
         </el-form>
       </el-col>
     </el-row>

--- a/src/views/ssbc/postTx/index.vue
+++ b/src/views/ssbc/postTx/index.vue
@@ -26,7 +26,7 @@
             <el-input v-model.number="form.value" maxlength="10"/>
           </el-form-item>
         </el-form>
-        <el-button type="primary" :disabled="disable" @click="postTran">发起交易</el-button>
+        <el-button type="primary" :disabled="disable" @click="postTran">发起转账</el-button>
       </el-col>
     </el-row>
   </div>

--- a/src/views/ssbc/postTx/index.vue
+++ b/src/views/ssbc/postTx/index.vue
@@ -6,7 +6,7 @@
         <el-form label-width="80px">
 
           <el-form-item label="发起地址">
-            <el-select v-model="form.from" style="width: 100%" class="filter-item">
+            <el-select v-model="form.from" style="width: 100%" class="filter-item" filterable>
               <el-option v-for="user in userList" :key="user.address" :label="user.address" :value="user.address" @click.native="chooseSender(user)" />
             </el-select>
           </el-form-item>
@@ -18,7 +18,7 @@
             <el-input v-model="form.public_key" :disabled="true" />
           </el-form-item>
           <el-form-item label="接收地址">
-            <el-select v-model="form.to" style="width: 100%">
+            <el-select v-model="form.to" style="width: 100%" filterable>
               <el-option v-for="user in userList" :key="user.address" :label="user.address" :value="user.address" @click.native="chooseReceiver(user)" />
             </el-select>
           </el-form-item>

--- a/src/views/ssbc/register/index.vue
+++ b/src/views/ssbc/register/index.vue
@@ -6,7 +6,7 @@
 
     <el-form-item label="当前链" label-width="25%">
       <el-col :span="12">
-        <el-select v-model="sourceChain" style="width: 100%" class="filter-item">
+        <el-select v-model="sourceChain" style="width: 100%" class="filter-item" filterable>
           <el-option v-for="chainId in chainList" :key="chainId" :label="chainId" :value="chainId" @click.native="chooseChain(chainId)" />
         </el-select>
       </el-col>
@@ -14,7 +14,7 @@
 
     <el-form-item label="当前账户" label-width="25%">
       <el-col :span="12">
-        <el-select v-model="currentUserInfo.AccountAddress" style="width: 100%" class="filter-item">
+        <el-select v-model="currentUserInfo.AccountAddress" style="width: 100%" class="filter-item" filterable>
           <el-option v-for="user in userList" :key="user.address" :label="user.address" :value="user.address" @click.native="choose(user)" />
         </el-select>
       </el-col>


### PR DESCRIPTION
修复同一功能名称不一致的问题，页面中发起交易改为发起转账、创建合约改为发布合约；
在下拉列表选择框提供额外的搜索功能，提高易用性；
添加合约编写Go语言版本提示；
在发布合约页面的合约名称输入框添加输入提示和已输入字数实时检测；